### PR TITLE
Run correct set of integration tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,9 +3,13 @@
       jobs:
         - tox-linters
         - ansible-test-sanity
-        - ansible-role-tests
+        - ansible-role-tests-stable-py2
+        - ansible-role-tests-stable-py3
+        - ansible-role-tests-devel-py2
     gate:
       jobs:
         - tox-linters
         - ansible-test-sanity
-        - ansible-role-tests
+        - ansible-role-tests-stable-py2
+        - ansible-role-tests-stable-py3
+        - ansible-role-tests-devel-py2


### PR DESCRIPTION
Tests to run should be defined in the individual repo

`ansible-role-tests` has been replaced with individual tests for specific Python and Ansible versions